### PR TITLE
商品詳細表示の実装①

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order('created_at DESC')
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @items = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,8 +128,8 @@
       <% @items.each do |item| %>
       <li class='list'>
         <div class='item-img-content'> 
-        <%= image_tag item.image, class: "item-img" %>
-        <%# <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype)%> 
+        <%= link_to image_tag(item.image,class: "item-img") , item_path(item), method: :get %>
+        
           <%# *商品が売れたらsoid outを表示（購入機能実装後に実装する） %>
           <%# <div class='sold-out'>
           <span>Sold Out!!</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,12 +24,11 @@
     </div>
 
     
-<% if current_user == @items.user %>
+<% if user_signed_in? && current_user == @items.user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-<% end %>
-<% if user_signed_in? && current_user != @items.user %>
+<% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,110 @@
+<%= render "devise/shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @items.product_name %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag @items.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class="sold-out">
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+       <a>￥</a> <%= @items.selling_price %>
+      </span>
+      <span class="item-postage">
+        <%= @items.shipping_charges.name %>
+      </span>
+    </div>
+
+    
+<% if current_user == @items.user %>
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <p class="or-text">or</p>
+    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+<% end %>
+<% if user_signed_in? && current_user != @items.user %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+<% end %>
+
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @items.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @items.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @items.product_state.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @items.shipping_charges.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @items.shipping_area.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @items.shipping_day.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  
+  <a href="#" class="another-item"><%= @items.category.name %>をもっと見る</a>
+  
+</div>
+
+<%= render "devise/shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
   root to: "items#index"
 
-  resources :items, only: [:index,:new, :create]
+  resources :items, only: [:index,:new, :create, :show]
 
 end


### PR DESCRIPTION
# what
詳細ページの表示の実装
ログイン状況に応じて、詳細ページの仕様を分けました。

# why
詳細ページの表示の実装の為

・ ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/29b16fc13269b113cdd189fef11c2bc0

・ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/5d597d0e2904284fea3e1ba6b8ccadc7

・ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
https://gyazo.com/fc7d41b0a1507e0b32677a6118bebcba

レビューお願いします。